### PR TITLE
add read-only permissions for codecommit to allow codecommit source r…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.output.template
+.aws-sam

--- a/sam.template
+++ b/sam.template
@@ -5,6 +5,16 @@ Description: |
   A Serverless Application that handles seeding a CodeCommit repository with the 
   contents of a public repository. In practice, it's effectively a fork to CC.
 
+Metadata:
+  AWS::ServerlessRepo::Application:
+    Name: CopyRepoToCodeCommit
+    Description: This SAR app is designed for use in CloudFormation as a Custom Resource to copy the contents from a publicly-accessible Git repository to a CodeCommit repo. In practice, it's very similar to a fork of the repo to CodeCommit.
+    Author: Andy Hopper
+    SpdxLicenseId: MIT
+    ReadmeUrl: README.md
+    SemanticVersion: 1.0.3
+    SourceCodeUrl: https://github.com/andyhopp/copy-to-codecommit
+
 Resources:
   CodeCommitLambdaRole:
     Type: AWS::IAM::Role

--- a/sam.template
+++ b/sam.template
@@ -30,6 +30,9 @@ Resources:
           - Action: [ 'codecommit:GetRepository', 'codecommit:CreateBranch', 'codecommit:GitPush' ]
             Resource: '*'
             Effect: Allow
+          - Action: [ 'codecommit:BatchGet*', 'codecommit:BatchDescribe*', 'codecommit:Get*', 'codecommit:Describe*', 'codecommit:List*', 'codecommit:GitPull' ]
+            Resource: '*'
+            Effect: Allow
       Roles:
         - Ref: CodeCommitLambdaRole
 


### PR DESCRIPTION
I think adding read only permissions to the Lambda function will allow the use of a CodeCommit repo as the Source Repo without any other changes.

I wasn't sure how to bump the SAR Application SematicVersion - maybe you can add it to the sam.template as well?